### PR TITLE
fix: allow upload without TEKs

### DIFF
--- a/immuni_exposure_ingestion/models/upload.py
+++ b/immuni_exposure_ingestion/models/upload.py
@@ -32,7 +32,7 @@ class Upload(Document):
     """
 
     to_publish = BooleanField(default=True)
-    keys = EmbeddedDocumentListField(TemporaryExposureKey, required=True)
+    keys = EmbeddedDocumentListField(TemporaryExposureKey, required=False, default=[])
     symptoms_started_on = DateField(required=True)
 
     meta = {"indexes": ["to_publish"]}


### PR DESCRIPTION
## Description

Allow an upload even if the TEKs list is empty.

1. Added default value to `Upload.keys`
2. Updated common module
3. Added tests

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

- Fixes #3 
