### PR TITLE
feat: add symptoms_started_on to analytics data

### DIFF
--- a/immuni_exposure_ingestion/apis/ingestion.py
+++ b/immuni_exposure_ingestion/apis/ingestion.py
@@ -139,7 +139,11 @@ async def upload(  # pylint: disable=too-many-arguments
 
     _LOGGER.info("Created new upload.", extra=dict(n_teks=len(teks)))
 
-    await store_exposure_detection_summaries(exposure_detection_summaries, province=province)
+    await store_exposure_detection_summaries(
+        exposure_detection_summaries,
+        province=province,
+        symptoms_started_on=otp.symptoms_started_on,
+    )
 
     return HTTPResponse(status=HTTPStatus.NO_CONTENT)
 

--- a/immuni_exposure_ingestion/helpers/exposure_data.py
+++ b/immuni_exposure_ingestion/helpers/exposure_data.py
@@ -12,6 +12,7 @@
 #    along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import json
+from datetime import date
 from typing import List
 
 from immuni_common.models.dataclasses import ExposureDetectionSummary
@@ -21,21 +22,25 @@ from immuni_exposure_ingestion.core.managers import managers
 
 
 async def store_exposure_detection_summaries(
-    exposure_detection_summaries: List[ExposureDetectionSummary], province: str
+    exposure_detection_summaries: List[ExposureDetectionSummary],
+    province: str,
+    symptoms_started_on: date,
 ) -> None:
     """
     Store the given exposure detection summaries into the Analytics Redis.
 
     :param exposure_detection_summaries: the summaries to be stored.
     :param province: the province associated with the summaries.
+    :param symptoms_started_on: the day in which the symptoms first appeared.
     """
     await managers.analytics_redis.rpush(
         config.ANALYTICS_QUEUE_KEY,
         json.dumps(
             dict(
-                version=1,
+                version=2,
                 payload=dict(
                     province=province,
+                    symptoms_started_on=symptoms_started_on.isoformat(),
                     exposure_detection_summaries=ExposureDetectionSummarySchema().dump(
                         exposure_detection_summaries, many=True
                     ),

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -324,8 +324,10 @@ async def test_upload_otp_complete(
     content = json.loads(enqueued_message)
 
     assert content == dict(
-        version=1,
+        version=2,
         payload=dict(
-            province="AG", exposure_detection_summaries=upload_data["exposure_detection_summaries"],
+            province="AG",
+            symptoms_started_on=date.today().isoformat(),
+            exposure_detection_summaries=upload_data["exposure_detection_summaries"],
         ),
     )


### PR DESCRIPTION
## Description

This PR adds a new field `symptoms_started_on` to the data sent to analytics. 

BREAKING CHANGE: payload version has been bumped to 2

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
