### PR TITLE
fix: Unused MAX_ALLOWED_CLIENT_SKEW_IN_SECONDS config

### DIFF
--- a/immuni_exposure_ingestion/core/config.py
+++ b/immuni_exposure_ingestion/core/config.py
@@ -12,7 +12,6 @@
 #    along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-from datetime import timedelta
 
 from decouple import config
 
@@ -56,10 +55,6 @@ DUMMY_DATA_TOKEN_ERROR_CHANCE_PERCENT: int = config(
 
 MAX_KEYS_PER_UPLOAD: int = config("MAX_KEYS_PER_UPLOAD", cast=int, default=14)
 MAX_KEYS_PER_BATCH: int = config("MAX_KEYS_PER_BATCH", cast=int, default=10000)
-
-MAX_ALLOWED_CLIENT_SKEW_IN_SECONDS: int = config(
-    "MAX_ALLOWED_CLIENT_SKEW_IN_SECONDS", cast=int, default=timedelta(hours=1).total_seconds()
-)
 
 DAYS_BEFORE_SYMPTOMS_TO_CONSIDER_KEY_AT_RISK: int = config(
     "DAYS_BEFORE_SYMPTOMS_TO_CONSIDER_KEY_AT_RISK", cast=int, default=2


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

Unused code is removed and an unused import also removed.

This PR tackles:

- Unused code in the core/config.py file


## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

<!-- Please insert the issue numbers after the # symbol -->

- Fixes #12 