### PR TITLE
[DO NOT MERGE] feat(logging): log on caller side

### DIFF
--- a/immuni_exposure_ingestion/models/upload.py
+++ b/immuni_exposure_ingestion/models/upload.py
@@ -70,15 +70,12 @@ class Upload(Document):
         cls.objects(id__in=ids).update(to_publish=False)
 
     @classmethod
-    def delete_older_than(cls, datetime_: datetime) -> None:
+    def delete_older_than(cls, datetime_: datetime) -> int:
         """
         Delete all Uploads older than the given datetime.
 
         :param datetime_: the datetime to check against.
+        :return: the number of deleted documents.
         """
         objects = cls.objects.filter(id__lte=ObjectId.from_datetime(datetime_))
-        n_deleted = objects.delete()
-        _LOGGER.info(
-            "Upload documents deletion completed.",
-            extra=dict(n_deleted=n_deleted, created_before=datetime_.isoformat()),
-        )
+        return objects.delete()

--- a/immuni_exposure_ingestion/tasks/delete_old_data.py
+++ b/immuni_exposure_ingestion/tasks/delete_old_data.py
@@ -40,5 +40,14 @@ def delete_old_data() -> None:
             "Some Upload objects were unprocessed until deleted! This should never happen!"
         )
 
-    Upload.delete_older_than(reference_date)
-    BatchFile.delete_older_than(reference_date)
+    n_deleted_uploads = Upload.delete_older_than(reference_date)
+    _LOGGER.info(
+        "Upload documents deletion completed.",
+        extra=dict(n_deleted=n_deleted_uploads, created_before=reference_date),
+    )
+
+    n_deleted_batch_files = BatchFile.delete_older_than(reference_date)
+    _LOGGER.info(
+        "BatchFile documents deletion completed.",
+        extra=dict(n_deleted=n_deleted_batch_files, created_before=reference_date),
+    )


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

A PR in immuni_backend_common moved the logging out of the BatchFile Mongo document, to be then called by the caller. This PR aims at adding such a caller logging and consistently apply the same logic for the Upload Mongo model.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
