### PR TITLE
fix: add maximum size validation to padding

### DIFF
--- a/immuni_exposure_ingestion/apis/ingestion.py
+++ b/immuni_exposure_ingestion/apis/ingestion.py
@@ -100,7 +100,7 @@ bp = Blueprint("ingestion", url_prefix="ingestion")
     exposure_detection_summaries=fields.Nested(
         ExposureDetectionSummarySchema, required=True, many=True,
     ),
-    padding=fields.String(validate=Regexp(r"^[a-zA-Z0-9]*$")),
+    padding=fields.String(validate=Regexp(rf"^[a-zA-Z0-9]{{0,{config.MAX_PADDING_SIZE}}}$")),
 )
 @validate_token_format
 @cache(no_store=True)
@@ -172,7 +172,7 @@ async def upload(  # pylint: disable=too-many-arguments
 )
 @validate(
     location=Location.JSON,
-    padding=fields.String(required=True, validate=Regexp(r"^[a-zA-Z0-9]*$")),
+    padding=fields.String(validate=Regexp(rf"^[a-zA-Z0-9]{{0,{config.MAX_PADDING_SIZE}}}$")),
 )
 @validate_token_format
 @slow_down_request

--- a/immuni_exposure_ingestion/core/config.py
+++ b/immuni_exposure_ingestion/core/config.py
@@ -87,3 +87,5 @@ BATCH_PERIODICITY_CRONTAB: str = config(
 DELETE_OLD_DATA_CRONTAB: str = config(
     "DELETE_OLD_DATA_CRONTAB", cast=validate_crontab("DELETE_OLD_DATA_CRONTAB"), default="0 0 * * *"
 )
+
+MAX_PADDING_SIZE: int = config("MAX_PADDING_SIZE", default=150_000)

--- a/immuni_exposure_ingestion/core/config.py
+++ b/immuni_exposure_ingestion/core/config.py
@@ -88,4 +88,4 @@ DELETE_OLD_DATA_CRONTAB: str = config(
     "DELETE_OLD_DATA_CRONTAB", cast=validate_crontab("DELETE_OLD_DATA_CRONTAB"), default="0 0 * * *"
 )
 
-MAX_PADDING_SIZE: int = config("MAX_PADDING_SIZE", default=150_000)
+MAX_PADDING_SIZE: int = config("MAX_PADDING_SIZE", cast=int, default=150_000)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -329,3 +329,26 @@ async def test_upload_otp_complete(
             province="AG", exposure_detection_summaries=upload_data["exposure_detection_summaries"],
         ),
     )
+
+
+@pytest.mark.parametrize("invalid_padding", ["\\asd*&!@#", "a" * (config.MAX_PADDING_SIZE + 1)])
+async def test_invalid_paddings_upload(
+    client: TestClient,
+    invalid_padding: str,
+    otp: OtpData,
+    auth_headers: Dict[str, str],
+    upload_data: Dict,
+) -> None:
+    upload_data["padding"] = invalid_padding
+    response = await client.post("/v1/ingestion/upload", json=upload_data, headers=auth_headers,)
+    assert response.status == 400
+
+
+@pytest.mark.parametrize("invalid_padding", ["\\asd*&!@#", "a" * (config.MAX_PADDING_SIZE + 1)])
+async def test_invalid_paddings_check_otp(
+    client: TestClient, invalid_padding: str, auth_headers: Dict[str, str],
+) -> None:
+    response = await client.post(
+        "/v1/ingestion/check-otp", json=dict(padding=invalid_padding), headers=auth_headers,
+    )
+    assert response.status == 400


### PR DESCRIPTION
## Description

Limit the maximum size of a padding in the upload and check-otp endpoints. 

## Checklist

- [X] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md).
- [X] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [X] I have written new tests for my core changes, as applicable.
- [X] I have successfully run tests with my changes locally.
- [X] It is ready for review! :rocket: