### PR TITLE
fix(monitoring): status value to properly group labels

### DIFF
--- a/immuni_exposure_ingestion/apis/ingestion.py
+++ b/immuni_exposure_ingestion/apis/ingestion.py
@@ -128,7 +128,7 @@ async def upload(  # pylint: disable=too-many-arguments
 
     if is_dummy:
         await wait_configured_time()  # Simulate the time of a real request
-        return HTTPResponse(status=HTTPStatus.NO_CONTENT)
+        return HTTPResponse(status=HTTPStatus.NO_CONTENT.value)
 
     upload_model = Upload(keys=teks)
 
@@ -141,7 +141,7 @@ async def upload(  # pylint: disable=too-many-arguments
 
     await store_exposure_detection_summaries(exposure_detection_summaries, province=province)
 
-    return HTTPResponse(status=HTTPStatus.NO_CONTENT)
+    return HTTPResponse(status=HTTPStatus.NO_CONTENT.value)
 
 
 @bp.route("/check-otp", version=1, methods=["POST"])
@@ -189,7 +189,7 @@ async def check_otp(request: Request, is_dummy: bool, padding: str) -> HTTPRespo
     if is_dummy:
         if secrets.randbelow(100) < config.DUMMY_DATA_TOKEN_ERROR_CHANCE_PERCENT:
             raise UnauthorizedOtpException()
-        return HTTPResponse(status=HTTPStatus.NO_CONTENT)
+        return HTTPResponse(status=HTTPStatus.NO_CONTENT.value)
 
     await validate_otp_token(request.token)
-    return HTTPResponse(status=HTTPStatus.NO_CONTENT)
+    return HTTPResponse(status=HTTPStatus.NO_CONTENT.value)


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

Return HTTP status value to properly group metrics labels.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
