### PR TITLE
fix: allow non consecutive teks

### DIFF
--- a/immuni_exposure_ingestion/apis/ingestion.py
+++ b/immuni_exposure_ingestion/apis/ingestion.py
@@ -34,7 +34,6 @@ from immuni_common.models.marshmallow.schemas import (
     ExposureDetectionSummarySchema,
     TemporaryExposureKeySchema,
 )
-from immuni_common.models.marshmallow.validators import TekListValidator
 from immuni_common.models.mongoengine.temporary_exposure_key import TemporaryExposureKey
 from immuni_common.models.swagger import HeaderImmuniContentTypeJson
 from immuni_exposure_ingestion.core import config
@@ -53,6 +52,7 @@ from immuni_exposure_ingestion.models.swagger import (
 )
 from immuni_exposure_ingestion.models.swagger import Upload as UploadDoc
 from immuni_exposure_ingestion.models.upload import Upload
+from immuni_exposure_ingestion.models.validators import TekListValidator
 from immuni_exposure_ingestion.monitoring.api import SUMMARIES_PROCESSED
 from immuni_exposure_ingestion.monitoring.helpers import monitor_check_otp, monitor_upload
 
@@ -209,7 +209,7 @@ async def check_otp(request: Request, is_dummy: bool, padding: str) -> HTTPRespo
     :param padding: the dummy data sent to protect against analysis of the traffic size.
     :return: 204 if the OTP is valid, 400 on SchemaValidationException, 401 on unauthorised OTP.
     """
-    
+
     # Dummy requests are currently being filtered at the reverse proxy level,
     # emulating the same behavior implemented below and introducing a response delay.
     # We may re-evaluate this decision in the future

--- a/immuni_exposure_ingestion/core/config.py
+++ b/immuni_exposure_ingestion/core/config.py
@@ -31,6 +31,8 @@ OTP_CACHE_REDIS_MAX_CONNECTIONS: int = config(
     "OTP_CACHE_REDIS_MAX_CONNECTIONS", default=10, cast=int
 )
 
+ALLOW_NON_CONSECUTIVE_TEKS: bool = config("ALLOW_NON_CONSECUTIVE_TEKS", cast=bool, default=False)
+
 ANALYTICS_BROKER_REDIS_URL: str = config(
     "ANALYTICS_BROKER_REDIS_URL", default="redis://localhost:6379/1"
 )

--- a/immuni_exposure_ingestion/models/validators.py
+++ b/immuni_exposure_ingestion/models/validators.py
@@ -39,19 +39,19 @@ class TekListValidator(Validator):
 
         if (n_keys := len(value)) > config.MAX_KEYS_PER_UPLOAD:
             raise ValidationError(
-                f"Too many TEKs. (actual: {n_keys}, max_allowed: {config.MAX_KEYS_PER_UPLOAD})"
+                f"Too many TEKs. (actual: {n_keys}, max_allowed: {config.MAX_KEYS_PER_UPLOAD})."
             )
 
         sorted_teks = sorted(value, key=operator.attrgetter("rolling_start_number"))
         rolling_start_numbers = [t.rolling_start_number for t in sorted_teks]
 
         if len(rolling_start_numbers) != len(set(rolling_start_numbers)):
-            raise ValidationError("Rolling start numbers are not unique")
+            raise ValidationError("Rolling start numbers are not unique.")
 
         next_rolling_start_number = sorted_teks[0].rolling_start_number
         for current in sorted_teks:
             if current.rolling_start_number < next_rolling_start_number:
-                raise ValidationError("Overlapping rolling start numbers")
+                raise ValidationError("Overlapping rolling start numbers.")
             next_rolling_start_number = current.rolling_start_number + current.rolling_period
 
         if config.ALLOW_NON_CONSECUTIVE_TEKS:
@@ -61,4 +61,4 @@ class TekListValidator(Validator):
         if rolling_start_numbers != [
             initial_start_number + 144 * i for i in range(len(rolling_start_numbers))
         ]:
-            raise ValidationError("Some TemporaryExposureKeys are missing!")
+            raise ValidationError("Some TemporaryExposureKeys are missing.")

--- a/immuni_exposure_ingestion/models/validators.py
+++ b/immuni_exposure_ingestion/models/validators.py
@@ -1,8 +1,10 @@
 from typing import List
 
-from immuni_common.models.mongoengine.temporary_exposure_key import TemporaryExposureKey
 from marshmallow import ValidationError
 from marshmallow.validate import Validator
+
+from immuni_common.models.mongoengine.temporary_exposure_key import TemporaryExposureKey
+from immuni_exposure_ingestion.core import config
 
 
 class TekListValidator(Validator):
@@ -35,12 +37,16 @@ class TekListValidator(Validator):
         if any(tek.rolling_period != 144 for tek in value):
             raise ValidationError("Some rolling values are not 144.")
 
-        if (n_keys := len(value)) > 14:
-            raise ValidationError(f"Too many TEKs. (actual: {n_keys}, max_allowed: 14)")
+        if (n_keys := len(value)) > config.MAX_KEYS_PER_UPLOAD:
+            raise ValidationError(
+                f"Too many TEKs. (actual: {n_keys}, max_allowed: {config.MAX_KEYS_PER_UPLOAD})"
+            )
 
         rolling_start_numbers = set(tek.rolling_start_number for tek in value)
         min_start_number = min(rolling_start_numbers)
-        expected_start_numbers = set(min_start_number + 144 * i for i in range(n_keys))
+        expected_start_numbers = set(
+            min_start_number + 144 * i for i in range(config.MAX_KEYS_PER_UPLOAD)
+        )
 
-        if rolling_start_numbers != expected_start_numbers:
+        if not rolling_start_numbers.issubset(expected_start_numbers):
             raise ValidationError("Unexpected rolling start numbers identified.")

--- a/immuni_exposure_ingestion/models/validators.py
+++ b/immuni_exposure_ingestion/models/validators.py
@@ -53,3 +53,12 @@ class TekListValidator(Validator):
             if current.rolling_start_number < next_rolling_start_number:
                 raise ValidationError("Overlapping rolling start numbers")
             next_rolling_start_number = current.rolling_start_number + current.rolling_period
+
+        if config.ALLOW_NON_CONSECUTIVE_TEKS:
+            return
+
+        initial_start_number = rolling_start_numbers[0]
+        if rolling_start_numbers != [
+            initial_start_number + 144 * i for i in range(len(rolling_start_numbers))
+        ]:
+            raise ValidationError("Some TemporaryExposureKeys are missing!")

--- a/immuni_exposure_ingestion/models/validators.py
+++ b/immuni_exposure_ingestion/models/validators.py
@@ -1,0 +1,46 @@
+from typing import List
+
+from immuni_common.models.mongoengine.temporary_exposure_key import TemporaryExposureKey
+from marshmallow import ValidationError
+from marshmallow.validate import Validator
+
+
+class TekListValidator(Validator):
+    """
+    A validator for a list of TEKs.
+    """
+
+    def __call__(self, value: List[TemporaryExposureKey]) -> None:
+        """
+        Validations to be performed according to Apple's documentation:
+
+        - Any ENIntervalNumber values from the same user are not unique.
+        - The period of time covered by the data file exceeds 14 days.
+        - There are any gaps in the ENIntervalNumber values for a user.
+        - Any keys in the file have overlapping time windows.
+        - The TEKRollingPeriod value is not 144.
+
+        :param value: the value of the schema being validated.
+        """
+
+        if len(value) == 0:
+            return
+
+        # NOTE: This kind of validation (rolling_period == 144) could be performed at field level.
+        #   We expect all of these validations to change in the future, so having them all together
+        #   here is done on purpose to make things simpler in case of changes in validation.
+        #   We would like to keep field validation more flexible as not to spread strict validation
+        #   logic in many places.
+
+        if any(tek.rolling_period != 144 for tek in value):
+            raise ValidationError("Some rolling values are not 144.")
+
+        if (n_keys := len(value)) > 14:
+            raise ValidationError(f"Too many TEKs. (actual: {n_keys}, max_allowed: 14)")
+
+        rolling_start_numbers = set(tek.rolling_start_number for tek in value)
+        min_start_number = min(rolling_start_numbers)
+        expected_start_numbers = set(min_start_number + 144 * i for i in range(n_keys))
+
+        if rolling_start_numbers != expected_start_numbers:
+            raise ValidationError("Unexpected rolling start numbers identified.")

--- a/immuni_exposure_ingestion/models/validators.py
+++ b/immuni_exposure_ingestion/models/validators.py
@@ -19,7 +19,6 @@ class TekListValidator(Validator):
 
         - Any ENIntervalNumber values from the same user are not unique.
         - The period of time covered by the data file exceeds 14 days.
-        - There are any gaps in the ENIntervalNumber values for a user.
         - Any keys in the file have overlapping time windows.
         - The TEKRollingPeriod value is not 144.
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -379,20 +379,3 @@ async def test_invalid_paddings_check_otp(
         "/v1/ingestion/check-otp", json=dict(padding=invalid_padding), headers=auth_headers,
     )
     assert response.status == 400
-
-
-async def test_upload_allows_non_consecutive_keys(
-    client: TestClient, otp: OtpData, auth_headers: Dict[str, str], upload_data: Dict,
-) -> None:
-    otp_sha = sha256("12345".encode("utf-8")).hexdigest()
-    auth_headers.update(CONTENT_TYPE_HEADER)
-
-    # Remove a random tek
-    del upload_data["teks"][3]
-
-    response = await client.post("/v1/ingestion/upload", json=upload_data, headers=auth_headers,)
-
-    assert response.status == 204
-    assert await managers.otp_redis.get(key_for_otp_sha(otp_sha)) is None
-
-    upload = Upload.objects.first()

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -297,6 +297,7 @@ async def test_upload_keys_with_missing_teks(
     assert response.status == HTTPStatus.BAD_REQUEST.value
 
 
+@mock_config(config, "ALLOW_NON_CONSECUTIVE_TEKS", True)
 @pytest.mark.parametrize("include_infos", [True, False])
 @pytest.mark.parametrize("include_summaries", [True, False])
 @pytest.mark.parametrize("include_teks", [True, False])

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,5 +1,79 @@
+from datetime import datetime, timedelta
+from typing import List, Dict
+
+import pytest
+from immuni_common.helpers.tests import mock_config
+from immuni_common.models.mongoengine.temporary_exposure_key import TemporaryExposureKey
+from marshmallow import ValidationError
+from pytest import raises
+
+from immuni_exposure_ingestion.core import config
 from immuni_exposure_ingestion.models.validators import TekListValidator
+from tests.fixtures.upload import generate_random_key_data
 
 
-def test_tek_key_validator_pass_if_empty() -> None:
+@pytest.fixture()
+def teks() -> List[TemporaryExposureKey]:
+    starting_period = int(
+        (
+            datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+            - timedelta(days=14)
+        ).timestamp()
+    )
+    return [
+        TemporaryExposureKey(
+            key_data=generate_random_key_data(),
+            rolling_period=144,
+            rolling_start_number=starting_period + 144 * i,
+        )
+        for i in range(14)
+    ]
+
+
+async def test_tek_key_validator_pass_if_empty() -> None:
     TekListValidator().__call__([])
+
+
+async def test_tek_key_validator_pass_with_correct_teks(teks: List[TemporaryExposureKey]) -> None:
+    TekListValidator().__call__(teks)
+
+
+@pytest.mark.parametrize("non_144_key", range(14))
+async def test_tek_key_validator_fails_if_any_key_has_period_not_144(
+    teks: List[TemporaryExposureKey], non_144_key: int
+) -> None:
+    teks[non_144_key].rolling_period = 100
+    with raises(ValidationError) as err:
+        TekListValidator().__call__(teks)
+
+    assert err.value.messages[0] == "Some rolling values are not 144."
+
+
+@mock_config(config, "MAX_KEYS_PER_UPLOAD", 13)
+async def test_tek_key_validator_fails_if_too_many_teks(teks: List[TemporaryExposureKey]) -> None:
+    with raises(ValidationError) as err:
+        TekListValidator().__call__(teks)
+
+    assert err.value.messages[0] == "Too many TEKs. (actual: 14, max_allowed: 13)"
+
+
+@pytest.mark.parametrize("duplicated_index", range(1, 13))
+async def test_tek_key_validator_fails_with_duplicated_start_numbers(
+    teks: List[TemporaryExposureKey], duplicated_index: int
+) -> None:
+    teks[duplicated_index]["rolling_start_number"] = teks[0]["rolling_start_number"]
+    with raises(ValidationError) as err:
+        TekListValidator().__call__(teks)
+
+    assert err.value.messages[0] == "Rolling start numbers are not unique"
+
+
+@pytest.mark.parametrize("overlapping_index", range(1, 13))
+async def test_tek_key_validator_fails_with_overlapping_periods(
+    teks: List[TemporaryExposureKey], overlapping_index: int
+) -> None:
+    teks[overlapping_index]["rolling_start_number"] = teks[0]["rolling_start_number"] + 1
+    with raises(ValidationError) as err:
+        TekListValidator().__call__(teks)
+
+    assert err.value.messages[0] == "Overlapping rolling start numbers"

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,5 @@
+from immuni_exposure_ingestion.models.validators import TekListValidator
+
+
+def test_tek_key_validator_pass_if_empty() -> None:
+    TekListValidator().__call__([])

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -77,3 +77,14 @@ async def test_tek_key_validator_fails_with_overlapping_periods(
         TekListValidator().__call__(teks)
 
     assert err.value.messages[0] == "Overlapping rolling start numbers"
+
+
+@pytest.mark.parametrize("missing_index", range(1, 12))
+async def test_tek_key_validator_fails_with_missing_teks(
+    teks: List[TemporaryExposureKey], missing_index: int
+) -> None:
+    del teks[missing_index]
+    with raises(ValidationError) as err:
+        TekListValidator().__call__(teks)
+
+    assert err.value.messages[0] == "Some TemporaryExposureKeys are missing!"

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timedelta
-from typing import List, Dict
+from typing import List
 
 import pytest
-from immuni_common.helpers.tests import mock_config
-from immuni_common.models.mongoengine.temporary_exposure_key import TemporaryExposureKey
 from marshmallow import ValidationError
 from pytest import raises
 
+from immuni_common.helpers.tests import mock_config
+from immuni_common.models.mongoengine.temporary_exposure_key import TemporaryExposureKey
 from immuni_exposure_ingestion.core import config
 from immuni_exposure_ingestion.models.validators import TekListValidator
 from tests.fixtures.upload import generate_random_key_data

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -54,7 +54,7 @@ async def test_tek_key_validator_fails_if_too_many_teks(teks: List[TemporaryExpo
     with raises(ValidationError) as err:
         TekListValidator().__call__(teks)
 
-    assert err.value.messages[0] == "Too many TEKs. (actual: 14, max_allowed: 13)"
+    assert err.value.messages[0] == "Too many TEKs. (actual: 14, max_allowed: 13)."
 
 
 @pytest.mark.parametrize("duplicated_index", range(1, 13))
@@ -65,7 +65,7 @@ async def test_tek_key_validator_fails_with_duplicated_start_numbers(
     with raises(ValidationError) as err:
         TekListValidator().__call__(teks)
 
-    assert err.value.messages[0] == "Rolling start numbers are not unique"
+    assert err.value.messages[0] == "Rolling start numbers are not unique."
 
 
 @pytest.mark.parametrize("overlapping_index", range(1, 13))
@@ -76,7 +76,7 @@ async def test_tek_key_validator_fails_with_overlapping_periods(
     with raises(ValidationError) as err:
         TekListValidator().__call__(teks)
 
-    assert err.value.messages[0] == "Overlapping rolling start numbers"
+    assert err.value.messages[0] == "Overlapping rolling start numbers."
 
 
 @pytest.mark.parametrize("missing_index", range(1, 12))
@@ -87,4 +87,4 @@ async def test_tek_key_validator_fails_with_missing_teks(
     with raises(ValidationError) as err:
         TekListValidator().__call__(teks)
 
-    assert err.value.messages[0] == "Some TemporaryExposureKeys are missing!"
+    assert err.value.messages[0] == "Some TemporaryExposureKeys are missing."


### PR DESCRIPTION
## Description

Some devices might send non-consecutive TEKs for various reasons. In this PR we change the validation of the TEKs in the upload endpoint to allow for this kind of keys to be uploaded anyway.

## Checklist

- [X] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md).
- [X] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [X] I have written new tests for my core changes, as applicable.
- [X] I have successfully run tests with my changes locally.
- [X] It is ready for review! :rocket: