### PR TITLE
fix: update common, use common tools when available

### DIFF
--- a/immuni_exposure_ingestion/celery.py
+++ b/immuni_exposure_ingestion/celery.py
@@ -12,13 +12,11 @@
 #    along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
-from typing import Any, List, Tuple
+from typing import Any, Tuple
 
-from celery.schedules import crontab
 from celery.signals import worker_process_init, worker_process_shutdown
-from croniter import croniter
 
-from immuni_common.celery import CeleryApp, Schedule
+from immuni_common.celery import CeleryApp, Schedule, string_to_crontab
 from immuni_exposure_ingestion import tasks
 from immuni_exposure_ingestion.core import config
 from immuni_exposure_ingestion.core.managers import managers
@@ -35,16 +33,9 @@ def _get_schedules() -> Tuple[Schedule, ...]:
     from immuni_exposure_ingestion.tasks.process_uploads import process_uploads
     from immuni_exposure_ingestion.tasks.delete_old_data import delete_old_data
 
-    def to_crontab_args(crontab_entry: str) -> List[str]:
-        return [",".join(map(str, x)) for x in croniter(crontab_entry).expanded]
-
     return (
-        Schedule(
-            task=process_uploads, when=crontab(*to_crontab_args(config.BATCH_PERIODICITY_CRONTAB))
-        ),
-        Schedule(
-            task=delete_old_data, when=crontab(*to_crontab_args(config.DELETE_OLD_DATA_CRONTAB))
-        ),
+        Schedule(task=process_uploads, when=string_to_crontab(config.BATCH_PERIODICITY_CRONTAB)),
+        Schedule(task=delete_old_data, when=string_to_crontab(config.DELETE_OLD_DATA_CRONTAB)),
     )
 
 

--- a/immuni_exposure_ingestion/core/config.py
+++ b/immuni_exposure_ingestion/core/config.py
@@ -48,8 +48,12 @@ CELERY_ALWAYS_EAGER: bool = config(
 
 DATA_RETENTION_DAYS: int = config("DATA_RETENTION_DAYS", cast=int, default=14)
 
-NOISE_REQUEST_TIMEOUT_MILLIS: int = config("NOISE_REQUEST_TIMEOUT", cast=int, default=150)
-NOISE_REQUEST_TIMEOUT_SIGMA: int = config("NOISE_REQUEST_TIMEOUT_SIGMA", cast=int, default=20)
+CHECK_OTP_REQUEST_TIMEOUT_MILLIS: int = config(
+    "CHECK_OTP_REQUEST_TIMEOUT_MILLIS", cast=int, default=150
+)
+CHECK_OTP_REQUEST_TIMEOUT_SIGMA: int = config(
+    "CHECK_OTP_REQUEST_TIMEOUT_SIGMA", cast=int, default=20
+)
 
 DUMMY_DATA_TOKEN_ERROR_CHANCE_PERCENT: int = config(
     "DUMMY_DATA_TOKEN_ERROR_CHANCE_PERCENT", cast=int, default=1

--- a/immuni_exposure_ingestion/monitoring/helpers.py
+++ b/immuni_exposure_ingestion/monitoring/helpers.py
@@ -4,6 +4,10 @@ from typing import Any, Callable, Coroutine
 from sanic.response import HTTPResponse
 
 from immuni_common.core.exceptions import ApiException
+from immuni_common.helpers.sanic import validate
+from immuni_common.models.enums import Location
+from immuni_common.models.marshmallow.fields import IntegerBoolField
+from immuni_common.models.swagger import HeaderImmuniDummyData
 from immuni_exposure_ingestion.monitoring.api import CHECK_OTP_REQUESTS, UPLOAD_REQUESTS
 
 
@@ -15,14 +19,19 @@ def monitor_upload(f: Callable[..., Coroutine[Any, Any, HTTPResponse]]) -> Calla
     """
 
     @wraps(f)
-    async def _wrapper(*args: Any, **kwargs: Any) -> HTTPResponse:
-        dummy = kwargs["is_dummy"]
+    @validate(
+        location=Location.HEADERS,
+        is_dummy=IntegerBoolField(
+            required=True, allow_strings=True, data_key=HeaderImmuniDummyData.DATA_KEY,
+        ),
+    )
+    async def _wrapper(*args: Any, is_dummy: bool, **kwargs: Any) -> HTTPResponse:
         province = kwargs["province"]
         try:
             response = await f(*args, **kwargs)
-            UPLOAD_REQUESTS.labels(dummy, province, response.status).inc()
+            UPLOAD_REQUESTS.labels(is_dummy, province, response.status).inc()
         except ApiException as error:
-            UPLOAD_REQUESTS.labels(dummy, province, error.status_code.value).inc()
+            UPLOAD_REQUESTS.labels(is_dummy, province, error.status_code.value).inc()
             raise
         return response
 
@@ -37,13 +46,18 @@ def monitor_check_otp(f: Callable[..., Coroutine[Any, Any, HTTPResponse]]) -> Ca
     """
 
     @wraps(f)
-    async def _wrapper(*args: Any, **kwargs: Any) -> HTTPResponse:
-        dummy = kwargs["is_dummy"]
+    @validate(
+        location=Location.HEADERS,
+        is_dummy=IntegerBoolField(
+            required=True, allow_strings=True, data_key=HeaderImmuniDummyData.DATA_KEY,
+        ),
+    )
+    async def _wrapper(*args: Any, is_dummy: bool, **kwargs: Any) -> HTTPResponse:
         try:
             response = await f(*args, **kwargs)
-            CHECK_OTP_REQUESTS.labels(dummy, response.status).inc()
+            CHECK_OTP_REQUESTS.labels(is_dummy, response.status).inc()
         except ApiException as error:
-            CHECK_OTP_REQUESTS.labels(dummy, error.status_code.value).inc()
+            CHECK_OTP_REQUESTS.labels(is_dummy, error.status_code.value).inc()
             raise
         return response
 


### PR DESCRIPTION
## Description

This PR updates the common submodule to the latest version. This includes some functions that were used in the exposure-ingestion system which are now imported from common.

NOTE: This also makes it necessary to change some ENV VARS:

NOISE_REQUEST_TIMEOUT_MILLIS -> DUMMY_REQUEST_TIMEOUT_MILLIS
NOISE_REQUEST_TIMEOUT_SIGMA -> DUMMY_REQUEST_TIMEOUT_SIGMA

Also, the slow_requests decorator does not use the same config, but uses a different config instead, which uses the variables:

CHECK_OTP_REQUEST_TIMEOUT_MILLIS and CHECK_OTP_REQUEST_TIMEOUT_SIGMA.

## Checklist

- [X] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md).
- [X] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [X] I have written new tests for my core changes, as applicable.
- [X] I have successfully run tests with my changes locally.
- [X] It is ready for review! :rocket: