### PR TITLE
feat: variable rolling period

### DIFF
--- a/immuni_exposure_ingestion/apis/ingestion.py
+++ b/immuni_exposure_ingestion/apis/ingestion.py
@@ -126,10 +126,10 @@ async def upload(  # pylint: disable=too-many-arguments
 
     # perform consistency checks in the list of uploaded teks
     try:
-        TekListValidator()(teks)
+        teks = TekListValidator()(teks)
     except ValidationError as exc:
         _LOGGER.error(
-            "Inconsistency detected in the uploaded teks",
+            "Inconsistency detected in the uploaded teks.",
             extra=dict(teks=[t.to_json() for t in teks], error=str(exc)),
         )
         # make sure not to save the inconsistent keys in the upload document

--- a/immuni_exposure_ingestion/celery.py
+++ b/immuni_exposure_ingestion/celery.py
@@ -44,7 +44,7 @@ def worker_process_init_listener(**kwargs: Any) -> None:
     """
     Callback on worker initialization.
     """
-    asyncio.run(managers.initialize())
+    asyncio.run(managers.initialize())  # pragma: no cover
 
 
 @worker_process_shutdown.connect
@@ -52,7 +52,7 @@ def worker_process_shutdown_listener(**kwargs: Any) -> None:
     """
     Callback on worker shutdown.
     """
-    asyncio.run(managers.teardown())
+    asyncio.run(managers.teardown())  # pragma: no cover
 
 
 celery_app = CeleryApp(

--- a/immuni_exposure_ingestion/core/config.py
+++ b/immuni_exposure_ingestion/core/config.py
@@ -31,7 +31,8 @@ OTP_CACHE_REDIS_MAX_CONNECTIONS: int = config(
     "OTP_CACHE_REDIS_MAX_CONNECTIONS", default=10, cast=int
 )
 
-ALLOW_NON_CONSECUTIVE_TEKS: bool = config("ALLOW_NON_CONSECUTIVE_TEKS", cast=bool, default=False)
+# Default to True as one could disable the bluetooth for more than a day.
+ALLOW_NON_CONSECUTIVE_TEKS: bool = config("ALLOW_NON_CONSECUTIVE_TEKS", cast=bool, default=True)
 
 ANALYTICS_BROKER_REDIS_URL: str = config(
     "ANALYTICS_BROKER_REDIS_URL", default="redis://localhost:6379/1"
@@ -59,7 +60,10 @@ DUMMY_DATA_TOKEN_ERROR_CHANCE_PERCENT: int = config(
     "DUMMY_DATA_TOKEN_ERROR_CHANCE_PERCENT", cast=int, default=1
 )
 
-MAX_KEYS_PER_UPLOAD: int = config("MAX_KEYS_PER_UPLOAD", cast=int, default=14)
+# [14 days before TEKs + (possibly) 1 current day TEK with rolling_period up until "now" = 15 TEKs]
+# Yet, since the upload could fail (e.g., connection error), there could be multiple TEKs per day.
+# Following Google's suggestion, some slack is given here by setting it to 30.
+MAX_KEYS_PER_UPLOAD: int = config("MAX_KEYS_PER_UPLOAD", cast=int, default=30)
 MAX_KEYS_PER_BATCH: int = config("MAX_KEYS_PER_BATCH", cast=int, default=10000)
 
 DAYS_BEFORE_SYMPTOMS_TO_CONSIDER_KEY_AT_RISK: int = config(

--- a/immuni_exposure_ingestion/helpers/temporary_exposure_key.py
+++ b/immuni_exposure_ingestion/helpers/temporary_exposure_key.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timedelta, timezone
+
+_TEN_MINUTES_IN_SECONDS = timedelta(minutes=10).total_seconds()
+
+
+def now_rolling_start_number() -> int:
+    """
+    Compute the rolling start number as of now.
+
+    :return: the "now" rolling start number.
+    """
+    return _datetime_to_rolling_start_number(datetime.utcnow())
+
+
+def today_midnight_rolling_start_number() -> int:
+    """
+    Compute the rolling start number as of today at midnight.
+
+    :return: the rolling start number corresponding to today at midnight.
+    """
+    return _datetime_to_rolling_start_number(
+        datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+    )
+
+
+def _datetime_to_rolling_start_number(_datetime: datetime) -> int:
+    """
+    Given a datetime, return the corresponding rolling start number.
+
+    :param _datetime: the datetime whose rolling start is to be calculated.
+
+    :return: the rolling start corresponding to the given datetime.
+    """
+    return int(_datetime.replace(tzinfo=timezone.utc).timestamp() / _TEN_MINUTES_IN_SECONDS)

--- a/immuni_exposure_ingestion/models/validators.py
+++ b/immuni_exposure_ingestion/models/validators.py
@@ -1,3 +1,17 @@
+#    Copyright (C) 2020 Presidenza del Consiglio dei Ministri.
+#    Please refer to the AUTHORS file for more information.
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#    GNU Affero General Public License for more details.
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import logging
 import operator
 from typing import List
 
@@ -6,6 +20,15 @@ from marshmallow.validate import Validator
 
 from immuni_common.models.mongoengine.temporary_exposure_key import TemporaryExposureKey
 from immuni_exposure_ingestion.core import config
+from immuni_exposure_ingestion.helpers.temporary_exposure_key import (
+    now_rolling_start_number,
+    today_midnight_rolling_start_number,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_ROLLING_PERIOD_MIN = 1
+_ROLLING_PERIOD_MAX = 144
 
 
 class TekListValidator(Validator):
@@ -13,52 +36,130 @@ class TekListValidator(Validator):
     A validator for a list of TEKs.
     """
 
-    def __call__(self, value: List[TemporaryExposureKey]) -> None:
+    def __call__(self, teks: List[TemporaryExposureKey]) -> List[TemporaryExposureKey]:
         """
-        Validations to be performed according to Apple's documentation:
+        Perform the validation of a given list of TEKs, both on punctual value and as a whole.
 
-        - Any ENIntervalNumber values from the same user are not unique.
-        - The period of time covered by the data file exceeds 14 days.
-        - Any keys in the file have overlapping time windows.
-        - The TEKRollingPeriod value is not 144.
+        NOTE: The validation of a single TEKs could be performed at field level.
+          We expect (some of) these validations to change in the future. Having them all together
+          here aims at easing any future change in the validation steps.
 
-        :param value: the value of the schema being validated.
+        :param teks: the list of TEKs to be validated.
+
+        :raises ValidationError: in case at least one TEK is deemed invalid.
+        :return: the list of valid TEKs.
         """
 
-        if len(value) == 0:
-            return
+        n_teks = len(teks)
+        _LOGGER.info("Validating TEKs.", extra=dict(n_teks=n_teks))
 
-        # NOTE: This kind of validation (rolling_period == 144) could be performed at field level.
-        #   We expect all of these validations to change in the future, so having them all together
-        #   here is done on purpose to make things simpler in case of changes in validation.
-        #   We would like to keep field validation more flexible as not to spread strict validation
-        #   logic in many places.
+        if n_teks == 0:
+            return []
 
-        if any(tek.rolling_period != 144 for tek in value):
-            raise ValidationError("Some rolling values are not 144.")
+        self._validate_aggregate_values(teks=teks)
+        self._validate_single_values(teks=teks)
 
-        if (n_keys := len(value)) > config.MAX_KEYS_PER_UPLOAD:
+        return teks
+
+    @staticmethod
+    def _validate_aggregate_values(teks: List[TemporaryExposureKey]) -> None:
+        """
+        Validate the given TEKs, at an aggregate level.
+        Raise as soon as an invalid TEK is found.
+
+        :param teks: the list of TEKs to be validated.
+        :raises: ValidationError in case at least one TEK is deemed invalid.
+        """
+        n_teks = len(teks)
+        if n_teks > config.MAX_KEYS_PER_UPLOAD:
             raise ValidationError(
-                f"Too many TEKs. (actual: {n_keys}, max_allowed: {config.MAX_KEYS_PER_UPLOAD})."
+                f"Too many TEKs. (actual: {n_teks}, max_allowed: {config.MAX_KEYS_PER_UPLOAD})."
             )
 
-        sorted_teks = sorted(value, key=operator.attrgetter("rolling_start_number"))
-        rolling_start_numbers = [t.rolling_start_number for t in sorted_teks]
+        if len({tek.key_data for tek in teks}) != n_teks:
+            raise ValidationError("TEKs do not have unique key data.")
 
-        if len(rolling_start_numbers) != len(set(rolling_start_numbers)):
-            raise ValidationError("Rolling start numbers are not unique.")
+        if len({(tek.rolling_start_number, tek.rolling_period) for tek in teks}) != n_teks:
+            raise ValidationError("TEKs do not have unique (rolling_start_number, rolling_period).")
 
-        next_rolling_start_number = sorted_teks[0].rolling_start_number
-        for current in sorted_teks:
-            if current.rolling_start_number < next_rolling_start_number:
-                raise ValidationError("Overlapping rolling start numbers.")
-            next_rolling_start_number = current.rolling_start_number + current.rolling_period
+        unique_rolling_start_numbers = {
+            tek.rolling_start_number
+            for tek in sorted(teks, key=operator.attrgetter("rolling_start_number"))
+        }
 
-        if config.ALLOW_NON_CONSECUTIVE_TEKS:
-            return
+        initial_start_number = min(unique_rolling_start_numbers)
 
-        initial_start_number = rolling_start_numbers[0]
-        if rolling_start_numbers != [
-            initial_start_number + 144 * i for i in range(len(rolling_start_numbers))
+        if invalid_start_numbers := [
+            tek.rolling_start_number
+            for tek in teks
+            if (tek.rolling_start_number - initial_start_number) % _ROLLING_PERIOD_MAX != 0
         ]:
-            raise ValidationError("Some TemporaryExposureKeys are missing.")
+            raise ValidationError(
+                f"There are invalid rolling_start_number values "
+                f"(i.e., {','.join(str(number) for number in invalid_start_numbers)})."
+            )
+
+        if not config.ALLOW_NON_CONSECUTIVE_TEKS:
+            missing_rolling_start_numbers = {
+                initial_start_number + _ROLLING_PERIOD_MAX * i
+                for i in range(len(unique_rolling_start_numbers))
+            }.difference(unique_rolling_start_numbers)
+            if missing_rolling_start_numbers:
+                raise ValidationError(
+                    f"Some rolling_start_numbers are missing "
+                    f"(i.e., {','.join(str(number) for number in missing_rolling_start_numbers)})."
+                )
+
+    @staticmethod
+    def _validate_single_values(teks: List[TemporaryExposureKey]) -> None:
+        """
+        Validate the given TEKs, at single-TEK level.
+        Raise as soon as an invalid TEK is found.
+
+        :param teks: the list of TEKs to be validated.
+        :raises: ValidationError in case at least one TEK is deemed invalid.
+        """
+
+        valid_teks = list()
+        today_teks = list()
+        _now_rolling_start_number = now_rolling_start_number()
+        _today_midnight_rolling_start_number = today_midnight_rolling_start_number()
+
+        for tek in teks:
+
+            if _ROLLING_PERIOD_MIN <= tek.rolling_period <= _ROLLING_PERIOD_MAX:
+                valid_teks.append(tek)
+            else:
+                # The TEK is not coming from the exposure notification framework: immediate short
+                # circuit.
+                raise ValidationError(
+                    f"Some rolling_period values are not in "
+                    f"[{_ROLLING_PERIOD_MIN},{_ROLLING_PERIOD_MAX}] (e.g., {tek.rolling_period})."
+                )
+
+            if (
+                _today_midnight_rolling_start_number
+                <= tek.rolling_start_number
+                < _now_rolling_start_number
+            ):
+                today_teks.append(tek)
+            elif tek.rolling_start_number >= _now_rolling_start_number:
+                # The TEK is not coming from the exposure notification framework: immediate short
+                # circuit.
+                raise ValidationError(
+                    f"Some rolling_start_number values are in the future "
+                    f"(e.g., {tek.rolling_start_number})."
+                )
+
+        if today_teks:
+            _LOGGER.info(
+                "There are today's TEKs. "
+                "They could be later ignored based on a configuration variable.",
+                extra=dict(
+                    n_teks=len(teks),
+                    n_valid_teks=len(valid_teks),
+                    n_today_teks=len(today_teks),
+                    today_rolling_periods=list(tek.rolling_period for tek in today_teks),
+                    EXCLUDE_CURRENT_DAY_TEK=config.EXCLUDE_CURRENT_DAY_TEK,
+                ),
+            )

--- a/immuni_exposure_ingestion/tasks/process_uploads.py
+++ b/immuni_exposure_ingestion/tasks/process_uploads.py
@@ -41,7 +41,7 @@ def process_uploads() -> None:
     """
     Celery does not support async functions, so we wrap it around asyncio.run.
     """
-    asyncio.run(_process_uploads())
+    asyncio.run(_process_uploads())  # pragma: no cover
 
 
 async def _process_uploads() -> None:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from typing import List
+from unittest.mock import MagicMock, patch
 
 import pytest
 from marshmallow import ValidationError
@@ -8,17 +9,22 @@ from pytest import raises
 from immuni_common.helpers.tests import mock_config
 from immuni_common.models.mongoengine.temporary_exposure_key import TemporaryExposureKey
 from immuni_exposure_ingestion.core import config
-from immuni_exposure_ingestion.models.validators import TekListValidator
+from immuni_exposure_ingestion.helpers.temporary_exposure_key import (
+    _datetime_to_rolling_start_number,
+    today_midnight_rolling_start_number,
+)
+from immuni_exposure_ingestion.models.validators import (
+    _ROLLING_PERIOD_MAX,
+    _ROLLING_PERIOD_MIN,
+    TekListValidator,
+)
 from tests.fixtures.upload import generate_random_key_data
 
 
 @pytest.fixture()
 def teks() -> List[TemporaryExposureKey]:
-    starting_period = int(
-        (
-            datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
-            - timedelta(days=14)
-        ).timestamp()
+    starting_period = _datetime_to_rolling_start_number(
+        datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=14)
     )
     return [
         TemporaryExposureKey(
@@ -26,7 +32,7 @@ def teks() -> List[TemporaryExposureKey]:
             rolling_period=144,
             rolling_start_number=starting_period + 144 * i,
         )
-        for i in range(14)
+        for i in range(15)
     ]
 
 
@@ -34,57 +40,117 @@ async def test_tek_key_validator_pass_if_empty() -> None:
     TekListValidator().__call__([])
 
 
+@pytest.mark.parametrize(
+    "key_index, out_of_range_rolling_period",
+    (
+        (key_index, out_of_range_rolling_period)
+        for key_index in range(15)
+        for out_of_range_rolling_period in {
+            -1,
+            _ROLLING_PERIOD_MIN - 1,
+            _ROLLING_PERIOD_MAX + 1,
+            1024,
+        }
+    ),
+)
+async def test_tek_key_validator_fails_on_out_of_range_rolling_period(
+    teks: List[TemporaryExposureKey], key_index: int, out_of_range_rolling_period: int
+) -> None:
+    teks[key_index].rolling_period = out_of_range_rolling_period
+    with raises(ValidationError) as err:
+        TekListValidator().__call__(teks)
+
+    assert err.value.messages[0] == (
+        f"Some rolling_period values are not in "
+        f"[{_ROLLING_PERIOD_MIN},{_ROLLING_PERIOD_MAX}] (e.g., {out_of_range_rolling_period})."
+    )
+
+
+async def test_tek_key_validator_fails_on_future_rolling_start_number(
+    teks: List[TemporaryExposureKey],
+) -> None:
+    for tek in teks:
+        tek.rolling_start_number += 144
+    with raises(ValidationError) as err:
+        TekListValidator().__call__(teks)
+
+    assert err.value.messages[0] == (
+        f"Some rolling_start_number values are in the future "
+        f"(e.g., {teks[-1].rolling_start_number})."
+    )
+
+
 async def test_tek_key_validator_pass_with_correct_teks(teks: List[TemporaryExposureKey]) -> None:
     TekListValidator().__call__(teks)
 
 
-@pytest.mark.parametrize("non_144_key", range(14))
-async def test_tek_key_validator_fails_if_any_key_has_period_not_144(
-    teks: List[TemporaryExposureKey], non_144_key: int
-) -> None:
-    teks[non_144_key].rolling_period = 100
-    with raises(ValidationError) as err:
-        TekListValidator().__call__(teks)
-
-    assert err.value.messages[0] == "Some rolling values are not 144."
-
-
-@mock_config(config, "MAX_KEYS_PER_UPLOAD", 13)
+@mock_config(config, "MAX_KEYS_PER_UPLOAD", 3)
 async def test_tek_key_validator_fails_if_too_many_teks(teks: List[TemporaryExposureKey]) -> None:
     with raises(ValidationError) as err:
         TekListValidator().__call__(teks)
 
-    assert err.value.messages[0] == "Too many TEKs. (actual: 14, max_allowed: 13)."
+    assert err.value.messages[0] == f"Too many TEKs. (actual: {len(teks)}, max_allowed: 3)."
 
 
 @pytest.mark.parametrize("duplicated_index", range(1, 13))
-async def test_tek_key_validator_fails_with_duplicated_start_numbers(
+async def test_tek_key_validator_fails_with_duplicated_start_number_and_rolling_period(
     teks: List[TemporaryExposureKey], duplicated_index: int
 ) -> None:
     teks[duplicated_index]["rolling_start_number"] = teks[0]["rolling_start_number"]
+    teks[duplicated_index]["rolling_period"] = teks[0]["rolling_period"]
     with raises(ValidationError) as err:
         TekListValidator().__call__(teks)
 
-    assert err.value.messages[0] == "Rolling start numbers are not unique."
+    assert (
+        err.value.messages[0] == "TEKs do not have unique (rolling_start_number, rolling_period)."
+    )
 
 
 @pytest.mark.parametrize("overlapping_index", range(1, 13))
 async def test_tek_key_validator_fails_with_overlapping_periods(
     teks: List[TemporaryExposureKey], overlapping_index: int
 ) -> None:
-    teks[overlapping_index]["rolling_start_number"] = teks[0]["rolling_start_number"] + 1
+    overlapping_start_number = teks[0]["rolling_start_number"] + 1
+    teks[overlapping_index]["rolling_start_number"] = overlapping_start_number
     with raises(ValidationError) as err:
         TekListValidator().__call__(teks)
 
-    assert err.value.messages[0] == "Overlapping rolling start numbers."
+    assert (
+        err.value.messages[0]
+        == f"There are invalid rolling_start_number values (i.e., {overlapping_start_number})."
+    )
 
 
+@mock_config(config, "ALLOW_NON_CONSECUTIVE_TEKS", False)
 @pytest.mark.parametrize("missing_index", range(1, 12))
 async def test_tek_key_validator_fails_with_missing_teks(
     teks: List[TemporaryExposureKey], missing_index: int
 ) -> None:
+    missing_rolling_start_number = teks[missing_index].rolling_start_number
     del teks[missing_index]
     with raises(ValidationError) as err:
         TekListValidator().__call__(teks)
 
-    assert err.value.messages[0] == "Some TemporaryExposureKeys are missing."
+    assert (
+        err.value.messages[0]
+        == f"Some rolling_start_numbers are missing (i.e., {missing_rolling_start_number})."
+    )
+
+
+@patch("immuni_exposure_ingestion.models.validators._LOGGER.info")
+async def test_tek_key_validator_finds_todays_teks(
+    logger: MagicMock, teks: List[TemporaryExposureKey]
+) -> None:
+    teks = teks[:1]
+    teks[0].rolling_start_number = today_midnight_rolling_start_number()
+    TekListValidator().__call__(teks)
+    logger.assert_called_with(
+        "There are today's TEKs. " "They could be later ignored based on a configuration variable.",
+        extra=dict(
+            n_teks=len(teks),
+            n_valid_teks=len(teks),
+            n_today_teks=len(teks),
+            today_rolling_periods=list(tek.rolling_period for tek in teks),
+            EXCLUDE_CURRENT_DAY_TEK=config.EXCLUDE_CURRENT_DAY_TEK,
+        ),
+    )


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

Allow rolling period in [0,144]. By default, allow holes in the uploaded TEKs rollingStartNumber (e.g., bluethoot has been disabled for at least one day).

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
