### PR TITLE
fix(poetry): add setuptool build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,5 +18,5 @@ responses = "^0.10.14"
 checks = "common.scripts:checks"
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=0.12", "setuptools"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

In the past days, poetry started showing ModuleNotFoundError: No module named 'setuptools' when installing common from one of the microservices projects.

We also tried to upgrade poetry to the latest 1.1.0, but without improvements (different error, though).

In the future, we will evaluate again this "workaround".

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-exposure-ingestion/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
